### PR TITLE
tsg/instance: Add name tag to created instances

### DIFF
--- a/cmd/config/public.go
+++ b/cmd/config/public.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/joyent/triton-go"
 	"github.com/joyent/triton-go/authentication"
+	"github.com/joyent/tsg-cli/cmd/internal/config"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
-	"github.com/joyent/tsg-cli/cmd/internal/config"
 )
 
 type TritonClientConfig struct {
@@ -121,16 +121,8 @@ func GetTsgName() string {
 	return viper.GetString(config.KeyTsgGroupName)
 }
 
-func GetMachineName() string {
-	return viper.GetString(config.KeyInstanceName)
-}
-
-func GetMachineNamePrefix() string {
-	return viper.GetString(config.KeyInstanceNamePrefix)
-}
-
-func GetMachineBrand() string {
-	return viper.GetString(config.KeyInstanceBrand)
+func GetTsgTemplateID() string {
+	return viper.GetString(config.KeyTsgTemplateID)
 }
 
 func GetMachineFirewall() bool {
@@ -178,21 +170,6 @@ func GetMachineTags() map[string]string {
 	return nil
 }
 
-func GetSearchTags() map[string]interface{} {
-	if viper.IsSet(config.KeyInstanceTag) {
-		tags := make(map[string]interface{}, 0)
-		cfg := viper.GetStringSlice(config.KeyInstanceTag)
-		for _, i := range cfg {
-			m := strings.Split(i, "=")
-			tags[m[0]] = m[1]
-		}
-
-		return tags
-	}
-
-	return nil
-}
-
 func GetMachineMetadata() map[string]string {
 	if viper.IsSet(config.KeyInstanceMetadata) {
 		metadata := make(map[string]string, 0)
@@ -211,4 +188,3 @@ func GetMachineMetadata() map[string]string {
 func GetMachineUserdata() string {
 	return viper.GetString(config.KeyInstanceUserdata)
 }
-

--- a/cmd/internal/config/public.go
+++ b/cmd/internal/config/public.go
@@ -14,14 +14,12 @@ const (
 	KeySshKeyMaterial = "general.key-material"
 	KeySshKeyID       = "general.key-id"
 
-	KeyTsgGroupName = "compute.tsg.name"
+	KeyTsgGroupName  = "compute.tsg.name"
+	KeyTsgTemplateID = "compute.tss.template-id"
 
-	KeyInstanceName         = "compute.instance.name"
 	KeyInstanceCount        = "compute.instance.count"
-	KeyInstanceNamePrefix   = "compute.instance.name-prefix"
 	KeyInstanceFirewall     = "compute.instance.firewall"
 	KeyInstanceState        = "compute.instance.state"
-	KeyInstanceBrand        = "compute.instance.brand"
 	KeyInstanceNetwork      = "compute.instance.networks"
 	KeyInstanceTag          = "compute.instance.tag"
 	KeyInstanceMetadata     = "compute.instance.metadata"
@@ -32,4 +30,3 @@ const (
 
 	KeyImageId = "compute.image.id"
 )
-

--- a/cmd/tsg-cli/cmd/scale/public.go
+++ b/cmd/tsg-cli/cmd/scale/public.go
@@ -9,13 +9,13 @@
 package scale
 
 import (
+	"github.com/joyent/tsg-cli/cmd/agent/scale"
 	tsgc "github.com/joyent/tsg-cli/cmd/config"
+	"github.com/joyent/tsg-cli/cmd/internal/command"
+	"github.com/joyent/tsg-cli/cmd/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"github.com/joyent/tsg-cli/cmd/internal/command"
-	"github.com/joyent/tsg-cli/cmd/internal/config"
-	"github.com/joyent/tsg-cli/cmd/agent/scale"
 )
 
 var Cmd = &command.Command{
@@ -33,7 +33,7 @@ var Cmd = &command.Command{
 				return err
 			}
 
-			a, err := scale.NewGetComputeClient(c)
+			a, err := scale.NewComputeClient(c)
 			if err != nil {
 				return err
 			}
@@ -59,29 +59,17 @@ var Cmd = &command.Command{
 
 		{
 			const (
-				key          = config.KeyInstanceName
-				longName     = "name"
-				shortName    = "n"
+				key          = config.KeyTsgTemplateID
+				longName     = "template-id"
 				defaultValue = ""
-				description  = "Instance Name"
-			)
-
-			flags := parent.Cobra.Flags()
-			flags.StringP(longName, shortName, defaultValue, description)
-			viper.BindPFlag(key, flags.Lookup(longName))
-		}
-
-		{
-			const (
-				key          = config.KeyInstanceNamePrefix
-				longName     = "name-prefix"
-				defaultValue = ""
-				description  = "Instance Name Prefix"
+				description  = "TSG Template ID"
 			)
 
 			flags := parent.Cobra.Flags()
 			flags.String(longName, defaultValue, description)
 			viper.BindPFlag(key, flags.Lookup(longName))
+
+			parent.Cobra.MarkFlagRequired(longName)
 		}
 
 		{
@@ -133,19 +121,6 @@ var Cmd = &command.Command{
 				longName     = "state"
 				defaultValue = ""
 				description  = "Instance state (e.g. running)"
-			)
-
-			flags := parent.Cobra.Flags()
-			flags.String(longName, defaultValue, description)
-			viper.BindPFlag(key, flags.Lookup(longName))
-		}
-
-		{
-			const (
-				key          = config.KeyInstanceBrand
-				longName     = "brand"
-				defaultValue = ""
-				description  = "Instance brand (e.g. lx, kvm)"
 			)
 
 			flags := parent.Cobra.Flags()
@@ -261,4 +236,3 @@ This option can be used multiple times.`
 		return nil
 	},
 }
-


### PR DESCRIPTION
When a TSG creates instances, it was agreed we would add a name tag
of the following format:

`tsg-< templateID >-< instanceID >`

We will use the first 8 characters of the template ID and the
instance ID.