### PR TITLE
cli: logging enhancements for audit history

### DIFF
--- a/cmd/internal/config/public.go
+++ b/cmd/internal/config/public.go
@@ -15,7 +15,7 @@ const (
 	KeySshKeyID       = "general.key-id"
 
 	KeyTsgGroupName  = "compute.tsg.name"
-	KeyTsgTemplateID = "compute.tss.template-id"
+	KeyTsgTemplateID = "compute.tsg.template-id"
 
 	KeyInstanceCount        = "compute.instance.count"
 	KeyInstanceFirewall     = "compute.instance.firewall"

--- a/cmd/tsg-cli/main.go
+++ b/cmd/tsg-cli/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/joyent/tsg-cli/cmd/tsg-cli/cmd"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/sean-/conswriter"
 )
@@ -23,6 +24,7 @@ func main() {
 	}()
 
 	if err := cmd.Execute(); err != nil {
+		logger := zerolog.New(os.Stderr).With().Timestamp().Logger()
 		log.Error().Err(err).Msg("unable to run")
 		os.Exit(1)
 	}


### PR DESCRIPTION
This will allow customers to get useful information about their TSG

e.g. when it scales an instance, we get information as follows:

```
{"level":"info","account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_LAUNCH","description":"Launching new instance 8f7b10e4-75cd-6a5e-f3d0-dd5e9dbd46aa","time":"2018-04-10T15:08:06Z","message":"An instance was created due to a difference between the expected and actual instance count"}
{"level":"info","account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_LAUNCH","description":"Launching new instance 47db6901-4e4d-45f4-f6e2-a0324b5284d5","time":"2018-04-10T15:08:10Z","message":"An instance was created due to a difference between the expected and actual instance count"}
{"level":"info","account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_LAUNCH","description":"Launching new instance 8757c9a0-7202-6810-b93a-9e568dd875c2","time":"2018-04-10T15:08:15Z","message":"An instance was created due to a difference between the expected and actual instance count"}
{"level":"info","account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_LAUNCH","description":"Launching new instance b4e2e981-4fe4-c108-9b6c-b2a06a35934b","time":"2018-04-10T15:08:20Z","message":"An instance was created due to a difference between the expected and actual instance count"}
{"level":"info","account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_LAUNCH","description":"Launching new instance f6045d07-02d3-4268-f2ba-929b6c343733","time":"2018-04-10T15:08:25Z","message":"An instance was created due to a difference between the expected and actual instance count"}
```

When an instance is scaled down, we get information as follows:

```
{"account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_TERMINATE","description":"Terminating instance 8f7b10e4-75cd-6a5e-f3d0-dd5e9dbd46aa","time":"2018-04-10T15:16:04Z","message":"An instance was deleted due to a difference between the expected and actual instance count"}
{"account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_TERMINATE","description":"Terminating instance 47db6901-4e4d-45f4-f6e2-a0324b5284d5","time":"2018-04-10T15:16:04Z","message":"An instance was deleted due to a difference between the expected and actual instance count"}
{"account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_TERMINATE","description":"Terminating instance 8757c9a0-7202-6810-b93a-9e568dd875c2","time":"2018-04-10T15:16:05Z","message":"An instance was deleted due to a difference between the expected and actual instance count"}
{"account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_TERMINATE","description":"Terminating instance b4e2e981-4fe4-c108-9b6c-b2a06a35934b","time":"2018-04-10T15:16:05Z","message":"An instance was deleted due to a difference between the expected and actual instance count"}
{"account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_TERMINATE","description":"Terminating instance f6045d07-02d3-4268-f2ba-929b6c343733","time":"2018-04-10T15:16:06Z","message":"An instance was deleted due to a difference between the expected and actual instance count"}
```

Then when the health check passes and nothing on the TSG needs to change
we get information as follows:

```
{"level":"info","account_name":"productci","tsg_name":"test","status":"successful","notification_type":"TSG_INSTANCE_NO_OP","description":"Expected 5 instances in TSG: \"test\" - found 5 instances","time":"2018-04-10T15:14:03Z","message":"TSG is healthy"}
```