### PR TITLE
Support Base64 encoded values for problematic CLI arguments.

### DIFF
--- a/cmd/agent/scale/public.go
+++ b/cmd/agent/scale/public.go
@@ -184,7 +184,10 @@ func (c *AgentComputeClient) CreateInstance(templateID string) (*tcc.Instance, e
 	tags := make(map[string]string, 0)
 	tags["tsg.template"] = templateID
 
-	userdata := config.GetMachineUserdata()
+	userdata, err := config.GetMachineUserdata()
+	if err != nil {
+		return nil, err
+	}
 	if userdata != "" {
 		md["user-data"] = userdata
 	}
@@ -213,7 +216,10 @@ func (c *AgentComputeClient) CreateInstance(templateID string) (*tcc.Instance, e
 		params.Tags = tags
 	}
 
-	metadata := config.GetMachineMetadata()
+	metadata, err := config.GetMachineMetadata()
+	if err != nil {
+		return nil, err
+	}
 	if metadata != nil {
 		mergo.Merge(&md, metadata)
 	}


### PR DESCRIPTION
This commit adds support for passing a Base64 encoded values to a number of
CLI arguments such as `--userdata`, `--metadata` and `--key-material`, as these
often take values containing that are not only problematic to use inside the
Nomad job template, but also when executing `tsg-cli`.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>